### PR TITLE
Add Chrome extension to inject DeepWiki button

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -1,0 +1,28 @@
+(function() {
+  if (!location.hostname.endsWith('github.com')) return;
+  function insertButton() {
+    const nav = document.querySelector('ul.UnderlineNav-body');
+    if (!nav) return;
+    if (nav.dataset.deepwikiInjected) return;
+    nav.dataset.deepwikiInjected = 'true';
+
+    const li = document.createElement('li');
+    li.className = 'UnderlineNav-item';
+
+    const a = document.createElement('a');
+    a.textContent = '\u21ba DeepWiki';
+    a.href = 'https://deepwiki.example/?url=' + encodeURIComponent(location.href);
+    a.target = '_blank';
+    a.style.display = 'flex';
+    a.style.alignItems = 'center';
+
+    li.appendChild(a);
+    nav.insertBefore(li, nav.firstElementChild);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', insertButton);
+  } else {
+    insertButton();
+  }
+})();

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,0 +1,13 @@
+{
+  "manifest_version": 3,
+  "name": "DeepWiki Button",
+  "description": "Adds a DeepWiki button to GitHub repo navigation",
+  "version": "1.0",
+  "content_scripts": [
+    {
+      "matches": ["https://github.com/*"],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Chrome extension manifest
- add content script to prepend a DeepWiki button to GitHub repo navigation

## Testing
- `git status --short`
